### PR TITLE
Extract request and response values into named properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI tests
+
+on:
+  pull_request:
+  push:
+    - master
+
+jobs:
+  test:
+    runs-on: [windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+
+      - name: Install dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Run tests
+        run: dotnet test --configuration Release --no-restore --no-build --nologo

--- a/Serilog.HttpClient.sln
+++ b/Serilog.HttpClient.sln
@@ -1,5 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+#
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{AA7D5182-4380-4FEE-9C29-E82A7E18B238}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{73B9E424-BC51-4858-AB3B-5A848EC79CA1}"
@@ -9,6 +10,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.HttpClient.Samples.ConsoleApp", "samples\Serilog.HttpClient.Samples.ConsoleApp\Serilog.HttpClient.Samples.ConsoleApp.csproj", "{A4CD6F06-4763-44CE-B748-4BCF186FE584}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.HttpClient.Samples.AspNetCore", "samples\Serilog.HttpClient.Samples.AspNetCore\Serilog.HttpClient.Samples.AspNetCore.csproj", "{5D943CED-45BE-44F2-8662-A957793EA8A0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.HttpClient.Tests", "src\Serilog.HttpClient.Tests\Serilog.HttpClient.Tests.csproj", "{59FC1E95-1976-448D-AD15-DA273680780E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,10 +31,15 @@ Global
 		{5D943CED-45BE-44F2-8662-A957793EA8A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5D943CED-45BE-44F2-8662-A957793EA8A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5D943CED-45BE-44F2-8662-A957793EA8A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59FC1E95-1976-448D-AD15-DA273680780E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{59FC1E95-1976-448D-AD15-DA273680780E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{59FC1E95-1976-448D-AD15-DA273680780E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{59FC1E95-1976-448D-AD15-DA273680780E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{31475D8A-0222-4C02-8A8F-75E1C79187E5} = {AA7D5182-4380-4FEE-9C29-E82A7E18B238}
 		{A4CD6F06-4763-44CE-B748-4BCF186FE584} = {73B9E424-BC51-4858-AB3B-5A848EC79CA1}
 		{5D943CED-45BE-44F2-8662-A957793EA8A0} = {73B9E424-BC51-4858-AB3B-5A848EC79CA1}
+		{59FC1E95-1976-448D-AD15-DA273680780E} = {AA7D5182-4380-4FEE-9C29-E82A7E18B238}
 	EndGlobalSection
 EndGlobal

--- a/samples/Serilog.HttpClient.Samples.ConsoleApp/Serilog.HttpClient.Samples.ConsoleApp.csproj
+++ b/samples/Serilog.HttpClient.Samples.ConsoleApp/Serilog.HttpClient.Samples.ConsoleApp.csproj
@@ -6,7 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\Serilog.HttpClient\Serilog.HttpClient.csproj" />
       <ProjectReference Include="..\..\src\Serilog.HttpClient\Serilog.HttpClient.csproj" />
     </ItemGroup>
 

--- a/src/Serilog.HttpClient.Tests/LoggingDelegatingHandlerTests.cs
+++ b/src/Serilog.HttpClient.Tests/LoggingDelegatingHandlerTests.cs
@@ -45,7 +45,7 @@ public class LoggingDelegatingHandlerTests
             Assert.Single(logEvents);
 
             var logEvent = logEvents.First();
-            Assert.Equal("HTTP Client request {RequestMethod} {RequestUri} completed in {ElapsedMilliseconds:0.0000}ms", logEvent.MessageTemplate.Text);
+            Assert.Equal("HTTP {RequestMethod} {RequestScheme}://{RequestHost}{RequestPath}{RequestQueryString} responded {StatusCode} in {ElapsedMilliseconds:0.0000} ms", logEvent.MessageTemplate.Text);
             Assert.Equal(LogEventLevel.Information, logEvent.Level);
             Assert.Null(logEvent.Exception);
             Assert.Equal("POST", logEvent.Properties["RequestMethod"].LiteralValue());

--- a/src/Serilog.HttpClient.Tests/LoggingDelegatingHandlerTests.cs
+++ b/src/Serilog.HttpClient.Tests/LoggingDelegatingHandlerTests.cs
@@ -1,0 +1,105 @@
+using System.Collections.Immutable;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Moq;
+using Moq.Protected;
+using Serilog.Events;
+using Serilog.HttpClient.Tests.Support;
+using Serilog.Sinks.TestCorrelator;
+
+namespace Serilog.HttpClient.Tests;
+
+public class LoggingDelegatingHandlerTests
+{
+    private Mock<HttpMessageHandler> _msgHandler = new Mock<HttpMessageHandler>();
+
+    [Fact]
+    public void Test_Log_Request()
+    {
+        mockResponse(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent("this is the response body"),
+            Headers = {
+                    ETag = EntityTagHeaderValue.Any
+                }
+        });
+
+        var client = createHttpClient(new RequestLoggingOptions
+        {
+            ResponseBodyLogMode = LogMode.LogAll
+        });
+
+        using (TestCorrelator.CreateContext())
+        {
+            client.SendAsync(new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                RequestUri = new Uri("https://example.com/path?query=1"),
+                Content = new StringContent("this is the request body"),
+                Headers = {
+                    Referrer = new Uri("https://example.com/referrer")
+                }
+            });
+
+            var logEvents = TestCorrelator.GetLogEventsFromCurrentContext();
+            Assert.Single(logEvents);
+
+            var logEvent = logEvents.First();
+            Assert.Equal("HTTP Client request {RequestMethod} {RequestUri} completed in {ElapsedMilliseconds:0.0000}ms", logEvent.MessageTemplate.Text);
+            Assert.Equal(LogEventLevel.Information, logEvent.Level);
+            Assert.Null(logEvent.Exception);
+            Assert.Equal("POST", logEvent.Properties["RequestMethod"].LiteralValue());
+            Assert.Equal("https", logEvent.Properties["RequestScheme"].LiteralValue());
+            Assert.Equal("example.com", logEvent.Properties["RequestHost"].LiteralValue());
+            Assert.Equal("/path", logEvent.Properties["RequestPath"].LiteralValue());
+            Assert.Equal("?query=1", logEvent.Properties["RequestQueryString"].LiteralValue());
+            Assert.Equal("this is the request body", logEvent.Properties["RequestBodyString"].LiteralValue());
+            Assert.Null(logEvent.Properties["RequestBody"].LiteralValue());
+            Assert.Equal(
+                new Dictionary<string, string[]>()
+                {
+                    { "Referer", new string[] {"https://example.com/referrer"} }
+                },
+                logEvent.Properties["RequestHeaders"].LiteralValue()
+            );
+
+            Assert.Equal("OK", logEvent.Properties["StatusCode"].LiteralValue());
+            Assert.True((bool)logEvent.Properties["IsSucceed"].LiteralValue());
+            Assert.IsType<double>(logEvent.Properties["ElapsedMilliseconds"].LiteralValue());
+            Assert.Equal("this is the response body", logEvent.Properties["ResponseBodyString"].LiteralValue());
+            Assert.Null(logEvent.Properties["ResponseBody"].LiteralValue());
+            Assert.Equal(
+                new Dictionary<string, string[]>()
+                {
+                    { "ETag", new string[] {"*"} }
+                },
+                logEvent.Properties["ResponseHeaders"].LiteralValue()
+            );
+        }
+    }
+
+    private void mockResponse(HttpResponseMessage response)
+    {
+        var mockedProtected = _msgHandler.Protected();
+        var setupApiRequest = mockedProtected.Setup<Task<HttpResponseMessage>>(
+            "SendAsync",
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>()
+        );
+        var apiMockedResponse = setupApiRequest.ReturnsAsync(response);
+        apiMockedResponse.Verifiable();
+    }
+
+    private System.Net.Http.HttpClient createHttpClient(RequestLoggingOptions options)
+    {
+        Log.Logger = new LoggerConfiguration().WriteTo.TestCorrelator().CreateLogger();
+
+        options.Logger = Log.Logger;
+
+        var loggingHandler = new LoggingDelegatingHandler(options, _msgHandler.Object);
+        var client = new System.Net.Http.HttpClient(loggingHandler);
+        return client;
+    }
+}

--- a/src/Serilog.HttpClient.Tests/MaskHelperTests.cs
+++ b/src/Serilog.HttpClient.Tests/MaskHelperTests.cs
@@ -1,0 +1,30 @@
+using System.Collections.Immutable;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Moq;
+using Moq.Protected;
+using Serilog.Events;
+using Serilog.HttpClient.Tests.Support;
+using Serilog.Sinks.TestCorrelator;
+
+namespace Serilog.HttpClient.Tests;
+
+public class MaskHelperTests
+{
+    [Fact]
+    public void Test_MaskFields()
+    {
+        var blacklist = new string[] { "*token*" };
+        var mask = "*MASK*";
+
+        var result = "{\"token\": \"abc\"}".MaskFields(blacklist, mask);
+        Assert.Equal("{\"token\":\"*MASK*\"}", result);
+
+        result = "[{\"token\": \"abc\"}]".MaskFields(blacklist, mask);
+        Assert.Equal("[{\"token\":\"*MASK*\"}]", result);
+
+        result = "{\"nested\": {\"token\": \"abc\"}}".MaskFields(blacklist, mask);
+        Assert.Equal("{\"nested\":{\"token\":\"*MASK*\"}}", result);
+    }
+}

--- a/src/Serilog.HttpClient.Tests/Serilog.HttpClient.Tests.csproj
+++ b/src/Serilog.HttpClient.Tests/Serilog.HttpClient.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Serilog.HttpClient\Serilog.HttpClient.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Serilog.HttpClient.Tests/Support/Extensions.cs
+++ b/src/Serilog.HttpClient.Tests/Support/Extensions.cs
@@ -4,9 +4,27 @@ namespace Serilog.HttpClient.Tests.Support
 {
     public static class Extensions
     {
-        public static object LiteralValue(this LogEventPropertyValue @this)
+        public static object ToScalar(this LogEventPropertyValue @this)
         {
+            if (@this is not ScalarValue)
+                throw new ArgumentException("Must be a ScalarValue", nameof(@this));
             return ((ScalarValue)@this).Value;
+        }
+
+        public static IReadOnlyDictionary<ScalarValue, LogEventPropertyValue> ToDictionary(this LogEventPropertyValue @this)
+        {
+            if (@this is not DictionaryValue)
+                throw new ArgumentException("Must be a DictionaryValue", nameof(@this));
+
+            return ((DictionaryValue)@this).Elements;
+        }
+
+        public static IReadOnlyList<LogEventPropertyValue> ToSequence(this LogEventPropertyValue @this)
+        {
+            if (@this is not SequenceValue)
+                throw new ArgumentException("Must be a SequenceValue", nameof(@this));
+
+            return ((SequenceValue)@this).Elements;
         }
     }
 }

--- a/src/Serilog.HttpClient.Tests/Support/Extensions.cs
+++ b/src/Serilog.HttpClient.Tests/Support/Extensions.cs
@@ -1,0 +1,12 @@
+using Serilog.Events;
+
+namespace Serilog.HttpClient.Tests.Support
+{
+    public static class Extensions
+    {
+        public static object LiteralValue(this LogEventPropertyValue @this)
+        {
+            return ((ScalarValue)@this).Value;
+        }
+    }
+}

--- a/src/Serilog.HttpClient.Tests/Usings.cs
+++ b/src/Serilog.HttpClient.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/Serilog.HttpClient/LoggingDelegatingHandler.cs
+++ b/src/Serilog.HttpClient/LoggingDelegatingHandler.cs
@@ -195,13 +195,13 @@ namespace Serilog.HttpClient
                 using (Serilog.Context.LogContext.PushProperty("RequestQueryString", req.RequestUri.Query))
                 using (Serilog.Context.LogContext.PushProperty("RequestQuery", requestQuery))
                 using (Serilog.Context.LogContext.PushProperty("RequestBodyString", requestBodyText))
-                using (Serilog.Context.LogContext.PushProperty("RequestBody", requestBody))
+                using (Serilog.Context.LogContext.PushProperty("RequestBody", requestBody, destructureObjects: true))
                 using (Serilog.Context.LogContext.PushProperty("RequestHeaders", requestHeaders))
                 using (Serilog.Context.LogContext.PushProperty("StatusCode", resp?.StatusCode.ToString()))
                 using (Serilog.Context.LogContext.PushProperty("IsSucceed", isRequestOk))
                 using (Serilog.Context.LogContext.PushProperty("ElapsedMilliseconds", elapsedMs))
                 using (Serilog.Context.LogContext.PushProperty("ResponseBodyString", responseBodyText))
-                using (Serilog.Context.LogContext.PushProperty("ResponseBody", responseBody))
+                using (Serilog.Context.LogContext.PushProperty("ResponseBody", responseBody, destructureObjects: true))
                 using (Serilog.Context.LogContext.PushProperty("ResponseHeaders", responseHeaders))
                 {
                     _logger.Write(level, ex, _options.MessageTemplate);

--- a/src/Serilog.HttpClient/LoggingDelegatingHandler.cs
+++ b/src/Serilog.HttpClient/LoggingDelegatingHandler.cs
@@ -24,6 +24,7 @@ using System.Web;
 using Microsoft.Extensions.Options;
 using Serilog.Debugging;
 using Serilog.Events;
+using Serilog.Parsing;
 
 namespace Serilog.HttpClient
 {
@@ -31,17 +32,18 @@ namespace Serilog.HttpClient
     {
         private readonly RequestLoggingOptions _options;
         private readonly ILogger _logger;
+        private readonly MessageTemplate _messageTemplate;
 
         public LoggingDelegatingHandler(
             RequestLoggingOptions options,
             HttpMessageHandler httpMessageHandler = default)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
-            _logger =  options.Logger?.ForContext<LoggingDelegatingHandler>() ?? Serilog.Log.Logger.ForContext<LoggingDelegatingHandler>();
-
+            _logger = options.Logger?.ForContext<LoggingDelegatingHandler>() ?? Serilog.Log.Logger.ForContext<LoggingDelegatingHandler>();
+            _messageTemplate = new MessageTemplateParser().Parse(options.MessageTemplate);
             InnerHandler = httpMessageHandler ?? new HttpClientHandler();
         }
-        
+
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var start = Stopwatch.GetTimestamp();
@@ -62,14 +64,16 @@ namespace Serilog.HttpClient
 
         static double GetElapsedMilliseconds(long start, long stop)
         {
-            return (stop - start) * 1000 / (double) Stopwatch.Frequency;
+            return (stop - start) * 1000 / (double)Stopwatch.Frequency;
         }
-        
+
         private async Task LogRequest(HttpRequestMessage req, HttpResponseMessage resp, double elapsedMs,
             Exception ex)
         {
             var level = _options.GetLevel(req, resp, elapsedMs, ex);
             if (!_logger.IsEnabled(level)) return;
+
+            var properties = new List<LogEventProperty>();
 
             var requestBodyText = string.Empty;
             var responseBodyText = string.Empty;
@@ -86,15 +90,17 @@ namespace Serilog.HttpClient
                 {
                     if (!string.IsNullOrWhiteSpace(requestBodyText))
                     {
-                        try { 
+                        try
+                        {
                             requestBodyText = requestBodyText.MaskFields(_options.MaskedProperties.ToArray(),
                                 _options.MaskFormat);
-                        } catch (Exception) { }
+                        }
+                        catch (Exception) { }
 
                         if (requestBodyText.Length > _options.RequestBodyLogTextLengthLimit)
                             requestBodyText = requestBodyText.Substring(0, _options.RequestBodyLogTextLengthLimit);
                         else
-                            try { requestBody = System.Text.Json.JsonDocument.Parse(requestBodyText); }catch (Exception) { }
+                            try { requestBody = System.Text.Json.JsonDocument.Parse(requestBodyText); } catch (Exception) { }
                     }
                 }
                 else
@@ -102,7 +108,7 @@ namespace Serilog.HttpClient
                     requestBodyText = "(Not Logged)";
                 }
 
-                var requestHeader = new Dictionary<string, object>();
+                var requestHeaders = new Dictionary<string, object>();
                 if (_options.RequestHeaderLogMode == LogMode.LogAll ||
                     (!isRequestOk && _options.RequestHeaderLogMode == LogMode.LogFailures))
                 {
@@ -113,9 +119,9 @@ namespace Serilog.HttpClient
                         foreach (var item in valuesByKey)
                         {
                             if (item.Count() > 1)
-                                requestHeader.Add(item.Key, item.SelectMany(x => x.Value));
+                                requestHeaders.Add(item.Key, item.SelectMany(x => x.Value));
                             else
-                                requestHeader.Add(item.Key, item.First().Value);
+                                requestHeaders.Add(item.Key, item.First().Value);
                         }
                     }
                     catch (Exception headerParseException)
@@ -130,7 +136,7 @@ namespace Serilog.HttpClient
                     if (!string.IsNullOrWhiteSpace(req.RequestUri.Query))
                     {
                         var q = HttpUtility.ParseQueryString(req.RequestUri.Query);
-                        
+
                         foreach (var key in q.AllKeys)
                         {
                             requestQuery.Add(key, q[key]);
@@ -142,18 +148,15 @@ namespace Serilog.HttpClient
                     SelfLog.WriteLine("Cannot parse query string");
                 }
 
-                var requestData = new
-                {
-                    Method = req.Method,
-                    Scheme = req.RequestUri.Scheme,
-                    Host = req.RequestUri.Host,
-                    Path = req.RequestUri.AbsolutePath,
-                    QueryString = req.RequestUri.Query,
-                    Query = requestQuery,
-                    BodyString = requestBodyText,
-                    Body = requestBody,
-                    Header = requestHeader,
-                };
+                properties.Add(new LogEventProperty("RequestMethod", new ScalarValue(req.Method.Method)));
+                properties.Add(new LogEventProperty("RequestScheme", new ScalarValue(req.RequestUri.Scheme)));
+                properties.Add(new LogEventProperty("RequestHost", new ScalarValue(req.RequestUri.Host)));
+                properties.Add(new LogEventProperty("RequestPath", new ScalarValue(req.RequestUri.AbsolutePath)));
+                properties.Add(new LogEventProperty("RequestQueryString", new ScalarValue(req.RequestUri.Query)));
+                properties.Add(new LogEventProperty("RequestQuery", new ScalarValue(requestQuery)));
+                properties.Add(new LogEventProperty("RequestBodyString", new ScalarValue(requestBodyText)));
+                properties.Add(new LogEventProperty("RequestBody", new ScalarValue(requestBody)));
+                properties.Add(new LogEventProperty("RequestHeaders", new ScalarValue(requestHeaders)));
 
                 object responseBody = null;
                 if ((_options.ResponseBodyLogMode == LogMode.LogAll ||
@@ -163,15 +166,17 @@ namespace Serilog.HttpClient
                         responseBodyText = await resp?.Content.ReadAsStringAsync();
                     if (!string.IsNullOrWhiteSpace(responseBodyText))
                     {
-                        try {
+                        try
+                        {
                             responseBodyText = responseBodyText.MaskFields(_options.MaskedProperties.ToArray(),
                                 _options.MaskFormat);
-                        } catch (Exception) { }
+                        }
+                        catch (Exception) { }
 
                         if (responseBodyText.Length > _options.ResponseBodyLogTextLengthLimit)
                             responseBodyText = responseBodyText.Substring(0, _options.ResponseBodyLogTextLengthLimit);
                         else
-                            try { responseBody = System.Text.Json.JsonDocument.Parse(responseBodyText); }catch (Exception) { }
+                            try { responseBody = System.Text.Json.JsonDocument.Parse(responseBodyText); } catch (Exception) { }
                     }
                 }
                 else
@@ -179,12 +184,11 @@ namespace Serilog.HttpClient
                     responseBodyText = "(Not Logged)";
                 }
 
-                var responseHeader = new Dictionary<string, object>();
+                var responseHeaders = new Dictionary<string, object>();
                 if (_options.ResponseHeaderLogMode == LogMode.LogAll ||
                     (!isRequestOk && _options.ResponseHeaderLogMode == LogMode.LogFailures)
                     && resp != null)
                 {
-
                     try
                     {
                         var valuesByKey = resp.Headers
@@ -192,9 +196,9 @@ namespace Serilog.HttpClient
                         foreach (var item in valuesByKey)
                         {
                             if (item.Count() > 1)
-                                responseHeader.Add(item.Key, item.SelectMany(x => x.Value));
+                                responseHeaders.Add(item.Key, item.SelectMany(x => x.Value));
                             else
-                                responseHeader.Add(item.Key, item.First().Value);
+                                responseHeaders.Add(item.Key, item.First().Value);
                         }
                     }
                     catch (Exception headerParseException)
@@ -203,21 +207,15 @@ namespace Serilog.HttpClient
                     }
                 }
 
-                var responseData = new
-                {
-                    StatusCode = (int?)resp?.StatusCode,
-                    IsSucceed = isRequestOk,
-                    ElapsedMilliseconds = elapsedMs,
-                    BodyString = responseBodyText,
-                    Body = responseBody,
-                    Header = responseHeader,
-                };
+                properties.Add(new LogEventProperty("StatusCode", new ScalarValue(resp?.StatusCode.ToString())));
+                properties.Add(new LogEventProperty("IsSucceed", new ScalarValue(isRequestOk)));
+                properties.Add(new LogEventProperty("ElapsedMilliseconds", new ScalarValue(elapsedMs)));
+                properties.Add(new LogEventProperty("ResponseBodyString", new ScalarValue(responseBodyText)));
+                properties.Add(new LogEventProperty("ResponseBody", new ScalarValue(responseBody)));
+                properties.Add(new LogEventProperty("ResponseHeaders", new ScalarValue(responseHeaders)));
 
-                _logger.Write(level, ex, _options.MessageTemplate, new
-                {
-                    Request = requestData,
-                    Response = responseData,
-                });
+                var evt = new LogEvent(DateTimeOffset.Now, level, ex, _messageTemplate, properties);
+                _logger.Write(evt);
             }
         }
     }

--- a/src/Serilog.HttpClient/MaskHelper.cs
+++ b/src/Serilog.HttpClient/MaskHelper.cs
@@ -22,7 +22,7 @@ namespace Serilog.HttpClient
         /// <param name="mask">Mask format</param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
-     public static string MaskFields(this string json, string[] blacklist, string mask)
+        public static string MaskFields(this string json, string[] blacklist, string mask)
         {
             if (string.IsNullOrWhiteSpace(json))
             {
@@ -52,7 +52,7 @@ namespace Serilog.HttpClient
                 MaskFieldsFromJToken(jObject, blacklist, mask);
             }
 
-            return jsonObject.ToString();
+            return JsonConvert.SerializeObject(jsonObject);
         }
 
         private static void MaskFieldsFromJToken(JToken token, string[] blacklist, string mask)
@@ -74,14 +74,14 @@ namespace Serilog.HttpClient
                     }
                 }
 
-                // call recursive 
+                // call recursive
                 MaskFieldsFromJToken(jtoken, blacklist, mask);
             }
 
-            // replace 
+            // replace
             foreach (JToken el in removeList)
             {
-                var prop = (JProperty) el;
+                var prop = (JProperty)el;
                 prop.Value = mask;
             }
         }
@@ -113,7 +113,7 @@ namespace Serilog.HttpClient
             string mask)
         {
             return keyValuePairs.Select(pair => IsMaskMatch(pair.Key, blacklist)
-                    ? new KeyValuePair<string, IEnumerable<string>>(pair.Key, new[] {mask} )
+                    ? new KeyValuePair<string, IEnumerable<string>>(pair.Key, new[] { mask })
                     : new KeyValuePair<string, IEnumerable<string>>(pair.Key, pair.Value))
                 .ToList();
         }

--- a/src/Serilog.HttpClient/RequestLoggingOptions.cs
+++ b/src/Serilog.HttpClient/RequestLoggingOptions.cs
@@ -13,11 +13,11 @@ namespace Serilog.HttpClient
     public class RequestLoggingOptions
     {
         const string DefaultRequestCompletionMessageTemplate =
-            "HTTP {RequestMethod} {RequestScheme}://{RequestHost}{RequestPath}{RequestQueryString} responded {StatusCode} in {ElapsedMilliseconds:0.0000} ms";
+            "HTTP {RequestMethod} {RequestUri} responded {StatusCode} in {ElapsedMilliseconds:0.0000} ms";
 
         /// <summary>
         /// Gets or sets the message template. The default value is
-        /// <c>"HTTP {RequestMethod} {RequestScheme}://{RequestHost}{RequestPath}{RequestQueryString} responded {StatusCode} in {ElapsedMilliseconds:0.0000} ms"</c>.
+        /// <c>"HTTP {RequestMethod} {RequestUri} responded {StatusCode} in {ElapsedMilliseconds:0.0000} ms"</c>.
         /// </summary>
         /// <value>
         /// The message template.

--- a/src/Serilog.HttpClient/RequestLoggingOptions.cs
+++ b/src/Serilog.HttpClient/RequestLoggingOptions.cs
@@ -13,7 +13,7 @@ namespace Serilog.HttpClient
     public class RequestLoggingOptions
     {
         const string DefaultRequestCompletionMessageTemplate =
-            "HTTP Client Request Completed {@Context}";
+            "HTTP Client request {RequestMethod} {RequestUri} completed in {ElapsedMilliseconds:0.0000}ms";
 
         /// <summary>
         /// Gets or sets the message template. The default value is
@@ -28,7 +28,7 @@ namespace Serilog.HttpClient
         /// A function returning the <see cref="LogEventLevel"/> based on the <see cref="HttpRequestMessage"/>/<see cref="HttpResponseMessage"/> information,
         /// the number of elapsed milliseconds required for handling the request, and an <see cref="Exception" /> if one was thrown.
         /// The default behavior returns <see cref="LogEventLevel.Error"/> when the response status code is greater than 499 or if the
-        /// <see cref="Exception"/> is not null. Also default log level for 4xx range errors set to <see cref="LogEventLevel.Warning"/>   
+        /// <see cref="Exception"/> is not null. Also default log level for 4xx range errors set to <see cref="LogEventLevel.Warning"/>
         /// </summary>
         /// <value>
         /// A function returning the <see cref="LogEventLevel"/>.
@@ -65,7 +65,7 @@ namespace Serilog.HttpClient
         /// Properties to mask before logging to output to prevent sensitive data leakage
         /// </summary>
         public IList<string> MaskedProperties { get; } =
-            new List<string>() {"*password*", "*token*", "*clientsecret*", "*bearer*", "*authorization*", "*client-secret*","*otp"};
+            new List<string>() { "*password*", "*token*", "*clientsecret*", "*bearer*", "*authorization*", "*client-secret*", "*otp" };
         /// <summary>
         /// Mask format to replace with masked data
         /// </summary>
@@ -97,7 +97,7 @@ namespace Serilog.HttpClient
                 level = LogEventLevel.Error;
             else if ((int)resp.StatusCode >= 400)
                 level = LogEventLevel.Warning;
-            
+
             return level;
         }
     }

--- a/src/Serilog.HttpClient/RequestLoggingOptions.cs
+++ b/src/Serilog.HttpClient/RequestLoggingOptions.cs
@@ -13,11 +13,11 @@ namespace Serilog.HttpClient
     public class RequestLoggingOptions
     {
         const string DefaultRequestCompletionMessageTemplate =
-            "HTTP Client request {RequestMethod} {RequestUri} completed in {ElapsedMilliseconds:0.0000}ms";
+            "HTTP {RequestMethod} {RequestScheme}://{RequestHost}{RequestPath}{RequestQueryString} responded {StatusCode} in {ElapsedMilliseconds:0.0000} ms";
 
         /// <summary>
         /// Gets or sets the message template. The default value is
-        /// <c>"HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms"</c>.
+        /// <c>"HTTP {RequestMethod} {RequestScheme}://{RequestHost}{RequestPath}{RequestQueryString} responded {StatusCode} in {ElapsedMilliseconds:0.0000} ms"</c>.
         /// </summary>
         /// <value>
         /// The message template.


### PR DESCRIPTION
Thanks for making such a useful library! It was exactly what I need for a project.

I'm contributing a few improvements:

1. I extracted the request and response properties into named properties that can be referenced in the message template and more clearly identified in log event structure.
2. I added some tests cases, including around masking since that's critical for my project.
3. I added a github actions workflow to run the tests.

The log structure now looks like this:

```json
{
  "@t": "2022-07-10T20:07:56.1864620Z",
  "@m": "HTTP \"GET\" https://httpbin.org/anything responded \"OK\" in 511.9163 ms",
  "@i": "2d2b237c",
  "SourceContext": "Serilog.HttpClient.LoggingDelegatingHandler",
  "ResponseHeaders": {
    "Date": ["Sun, 10 Jul 2022 20:07:56 GMT"],
    "Connection": ["keep-alive"],
    "Server": ["gunicorn/19.9.0"],
    "Access-Control-Allow-Origin": ["*"],
    "Access-Control-Allow-Credentials": ["true"]
  },
  "ResponseBody": {
    "RootElement": { "ValueKind": "Object", "$type": "JsonElement" },
    "$type": "JsonDocument"
  },
  "ResponseBodyString": "{\"args\":{},\"data\":\"\",\"files\":{},\"form\":{},\"headers\":{\"Authorization\":\"*****\",\"Host\":\"httpbin.org\"},\"json\":null,\"method\":\"GET\",\"origin\":\"207.109.85.2\",\"url\":\"https://httpbin.org/anything\"}",
  "ElapsedMilliseconds": 511.91625,
  "IsSucceed": true,
  "StatusCode": "OK",
  "RequestHeaders": {
    "Authorization": ["*****"]
  },
  "RequestBody": null,
  "RequestBodyString": "",
  "RequestQuery": {},
  "RequestQueryString": "",
  "RequestPath": "/anything",
  "RequestHost": "httpbin.org",
  "RequestScheme": "https",
  "RequestUri": "https://httpbin.org/anything",
  "RequestMethod": "GET",
  "HttpMethod": "GET",
  "Uri": "https://httpbin.org/anything",
  "ActionId": "7c5b2f2b-a0c4-4d4e-950b-e8c220f907ea",
  "ActionName": "MyApp.Controllers.HttpController.Version (MyApp)",
  "RequestId": "0HMJ2LVG1FKIL:00000002",
  "ConnectionId": "0HMJ2LVG1FKIL",
  "Scope": ["HTTP GET https://httpbin.org/anything"]
}
```