### PR TITLE
fix: dont set InnerHandler in HttpClientFactory usage

### DIFF
--- a/samples/Serilog.HttpClient.Samples.AspNetCore/Program.cs
+++ b/samples/Serilog.HttpClient.Samples.AspNetCore/Program.cs
@@ -22,6 +22,7 @@ namespace Serilog.HttpClient.Samples.AspNetCore
             Host.CreateDefaultBuilder(args)
                 .UseSerilogPlus(p =>
                 {
+                    p.WriteTo.Console();
                     p.WriteTo.File(new CompactJsonFormatter(), "App_Data/Logs/log.json");
                 })
                 .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });

--- a/src/Serilog.HttpClient/Extensions/HttpClientBuilderExtensions.cs
+++ b/src/Serilog.HttpClient/Extensions/HttpClientBuilderExtensions.cs
@@ -25,7 +25,7 @@ namespace Serilog.HttpClient.Extensions
             builder.Services.TryAddTransient(s =>
             {
                 var o = s.GetRequiredService<IOptionsSnapshot<RequestLoggingOptions>>();
-                return new LoggingDelegatingHandler(o.Get(builder.Name));
+                return new LoggingDelegatingHandler(o.Get(builder.Name), default, true);
             });
             builder.AddHttpMessageHandler(s => s.GetRequiredService<LoggingDelegatingHandler>());
 

--- a/src/Serilog.HttpClient/LoggingDelegatingHandler.cs
+++ b/src/Serilog.HttpClient/LoggingDelegatingHandler.cs
@@ -37,16 +37,23 @@ namespace Serilog.HttpClient
 
         public LoggingDelegatingHandler(
             RequestLoggingOptions options,
-            HttpMessageHandler httpMessageHandler = default)
+            HttpMessageHandler httpMessageHandler = default, bool forHttpClientFactory = false)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _logger =  options.Logger?.ForContext<LoggingDelegatingHandler>() ?? Serilog.Log.Logger.ForContext<LoggingDelegatingHandler>();
 
-#if NETCOREAPP3_1_OR_GREATER            
-            InnerHandler = httpMessageHandler ?? new SocketsHttpHandler();
+#if NETCOREAPP3_1_OR_GREATER
+            if (!forHttpClientFactory)
+            {
+               InnerHandler = httpMessageHandler ?? new SocketsHttpHandler();
+            }
 #else
-            InnerHandler = httpMessageHandler ?? new HttpClientHandler();
+            if (!forHttpClientFactory)
+            {
+                InnerHandler = httpMessageHandler ?? new HttpClientHandler();
+            }
 #endif
+            
         }
         
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)


### PR DESCRIPTION
in HttpClientFactroy CreateHandlerPipeline prosses there is validation prevent create Handler with not null InnerHandler 
https://github.com/dotnet/runtime/blob/215b39abf947da7a40b0cb137eab4bceb24ad3e3/src/libraries/Microsoft.Extensions.Http/src/HttpMessageHandlerBuilder.cs#L103

this fail is exist in https://github.com/alirezavafi/serilog-httpclient/tree/master/samples/Serilog.HttpClient.Samples.AspNetCore

if other senario exist pls let me know i will cover them

