### PR TITLE
Remove HttpClientContext from message parameters because it's not referenced in the message template

### DIFF
--- a/samples/Serilog.HttpClient.Samples.ConsoleApp/Program.cs
+++ b/samples/Serilog.HttpClient.Samples.ConsoleApp/Program.cs
@@ -13,6 +13,8 @@ namespace Serilog.HttpClient.Samples.ConsoleApp
     {
         static void Main(string[] args)
         {
+            Serilog.Debugging.SelfLog.Enable(Console.Error);
+
             Serilog.Log.Logger = new LoggerConfiguration()
                 .WriteTo.File(new JsonFormatter(),$"log-{DateTime.Now:yyyyMMdd-HHmmss}.json")
                 .WriteTo.Console(outputTemplate:

--- a/src/Serilog.HttpClient/RequestLoggingOptions.cs
+++ b/src/Serilog.HttpClient/RequestLoggingOptions.cs
@@ -121,7 +121,7 @@ namespace Serilog.HttpClient
             return new LogEntryParameters()
             {
                 MessageTemplate = "HTTP Client {RequestMethod} {RequestPath} responded {StatusCode} in {ElapsedMilliseconds:0.0000} ms",
-                MessageParameters = new object[]{ h.Request.Method, h.Request.Path, h.Response.StatusCode, h.Response.ElapsedMilliseconds, h},
+                MessageParameters = new object[]{ h.Request.Method, h.Request.Path, h.Response.StatusCode, h.Response.ElapsedMilliseconds},
                 AdditionalProperties = { ["Context"] = h }
             };
         }


### PR DESCRIPTION
Serilog SelfLog is reporting an issue:
`Named property count does not match parameter count: HTTP Client {RequestMethod} {RequestPath} responded {StatusCode} in {ElapsedMilliseconds:0.0000} ms`
because of that extra unreferenced parameter.