### PR TITLE
Fix: Apply Unique LogRequestResponse Options for Multiple HttpClients

### DIFF
--- a/samples/Serilog.HttpClient.Samples.AspNetCore/Controllers/HomeController.cs
+++ b/samples/Serilog.HttpClient.Samples.AspNetCore/Controllers/HomeController.cs
@@ -8,15 +8,25 @@ namespace Serilog.HttpClient.Samples.AspNetCore.Controllers
     {
         private readonly IMyService _myService;
 
-        public HomeController(IMyService myService)
+        // for demonstrating multiple configurations of HttpClient
+        private readonly IMyOtherService _myOtherService;
+
+        public HomeController(IMyService myService, IMyOtherService myOtherService)
         {
-            _myService = myService;
+          _myService = myService;
+          _myOtherService = myOtherService;
         }
         
         public async Task<IActionResult> Index()
         {
            var result =  await _myService.SendRequest();
            return Ok(result);
+        }
+
+        public async Task<IActionResult> Other()
+        {
+          var otherResult = await _myOtherService.SendRequest();
+          return Ok(otherResult);
         }
     }
 }

--- a/samples/Serilog.HttpClient.Samples.AspNetCore/Services/IMyOtherService.cs
+++ b/samples/Serilog.HttpClient.Samples.AspNetCore/Services/IMyOtherService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Serilog.HttpClient.Samples.AspNetCore.Services
+{
+    public interface IMyOtherService
+    {
+        Task<object> SendRequest();
+    }
+}

--- a/samples/Serilog.HttpClient.Samples.AspNetCore/Services/MyOtherService.cs
+++ b/samples/Serilog.HttpClient.Samples.AspNetCore/Services/MyOtherService.cs
@@ -1,0 +1,24 @@
+// <copyright file="MyOtherService.cs" company="Sleep Outfitters USA">
+// Copyright (c) Sleep Outfitters USA. All rights reserved.
+// </copyright>
+
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace Serilog.HttpClient.Samples.AspNetCore.Services
+{
+    public class MyOtherService : IMyOtherService
+    {
+        private readonly System.Net.Http.HttpClient _httpClient;
+
+        public MyOtherService(System.Net.Http.HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public Task<object> SendRequest()
+        {
+            return _httpClient.GetFromJsonAsync<object>("https://reqres.in/api/users?page=1");
+        }
+    }
+}

--- a/samples/Serilog.HttpClient.Samples.AspNetCore/Startup.cs
+++ b/samples/Serilog.HttpClient.Samples.AspNetCore/Startup.cs
@@ -45,7 +45,18 @@ namespace Serilog.HttpClient.Samples.AspNetCore
                     //Proxy = new WebProxy("127.0.0.1", 8888)
                 });
             //or
- 
+            services
+              .AddHttpClient<IMyOtherService, MyOtherService>()
+              .CorrelateRequests("X-Correlation-ID")
+              .LogRequestResponse(p =>
+              {
+                p.LogMode = LogMode.LogNone;
+              })
+              // /*OR*/ .LogRequestResponse()
+              .ConfigurePrimaryHttpMessageHandler(p => new HttpClientHandler()
+              {
+                //Proxy = new WebProxy("127.0.0.1", 8888)
+              });
             services.AddControllers();
         }
 


### PR DESCRIPTION
This PR addresses the problem where custom RequestLoggingOptions applied via HttpClientBuilderExtensions.LogRequestResponse are not uniquely respected for multiple HttpClients in an ASP.NET Core app running on .NET 6. My changes ensure that each HttpClient correctly applies its configured logging options.

Additionally I added an additional service to the sample project to demonstrate the support for independent options.

Related Issue:
Fixes #6 